### PR TITLE
[js] Fix Nodejs mysql-raw.js

### DIFF
--- a/frameworks/JavaScript/nodejs/handlers/mysql-raw.js
+++ b/frameworks/JavaScript/nodejs/handlers/mysql-raw.js
@@ -1,6 +1,6 @@
 const h = require('../helper');
 const async = require('async');
-const mysql = require('mysql');
+const mysql = require('mysql2');
 const connection = mysql.createConnection({
   host: 'tfb-database',
   user: 'benchmarkdbuser',


### PR DESCRIPTION
Now use mysql2

Actually fail in the last runs:
https://tfb-status.techempower.com/unzip/results.2024-07-29-00-38-33-106.zip/results/20240723025336/nodejs-mysql-raw/run/nodejs-mysql-raw.log

And with this change also work with MySQL 9.0.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
